### PR TITLE
Fixed downloading multiple files when passing a list to "download_from_link"

### DIFF
--- a/qbittorrent/client.py
+++ b/qbittorrent/client.py
@@ -295,7 +295,10 @@ class Client(object):
             if options.get(old_arg) and not options.get(new_arg):
                 options[new_arg] = options[old_arg]
 
-        options['urls'] = link
+        if type(link) is list:
+            options['urls'] = "\n".join(link)
+        else:
+            options['urls'] = link
 
         # workaround to send multipart/formdata request
         # http://stackoverflow.com/a/23131823/4726598


### PR DESCRIPTION
The qBittorent web API spec shows that when sending the POST request to the download endpoint, all the magnet links should be formatted as such:

"link1" \n
"link2" \n
...

