### PR TITLE
Add support to bypass SSL verification

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,6 +55,16 @@ Quick usage guide
     for torrent in torrents:
         print torrent['name']
 
+
+If you have enabled SSL and are using a self-signed certificate, you'd probably want to disable SSL verification. This can be done by passing `verify=False` while initializing the `Client`.
+
+.. code-block:: python
+
+    from qbittorrent import Client
+
+    qb = Client('https://127.0.0.1:8080/', verify=False)
+
+
 API methods
 ===========
 

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -38,6 +38,16 @@ Quick usage guide
     for torrent in torrents:
         print torrent['name']
 
+
+If you have enabled SSL and are using a self-signed certificate, you'd probably want to disable SSL verification. This can be done by passing `verify=False` while initializing the `Client`.
+
+.. code-block:: python
+
+    from qbittorrent import Client
+
+    qb = Client('https://127.0.0.1:8080/', verify=False)
+
+
 Overview of API methods
 =======================
 


### PR DESCRIPTION
SSL verification can be disabled now by using `verify=False` while initializing the Client.

Closes #37 

Without verify=False.:
```
>>> client = Client('https://127.0.0.1:8080')
Traceback (most recent call last):
  File "/home/vikas/.virtualenvs/qbittorrent/lib/python3.6/site-packages/urllib3/connectionpool.py", line 672, in urlopen
    chunked=chunked,
  File "/home/vikas/.virtualenvs/qbittorrent/lib/python3.6/site-packages/urllib3/connectionpool.py", line 376, in _make_request
    self._validate_conn(conn)
  File "/home/vikas/.virtualenvs/qbittorrent/lib/python3.6/site-packages/urllib3/connectionpool.py", line 994, in _validate_conn
    conn.connect()
  File "/home/vikas/.virtualenvs/qbittorrent/lib/python3.6/site-packages/urllib3/connection.py", line 394, in connect
    ssl_context=context,
  File "/home/vikas/.virtualenvs/qbittorrent/lib/python3.6/site-packages/urllib3/util/ssl_.py", line 383, in ssl_wrap_socket
    return context.wrap_socket(sock)
  File "/usr/lib/python3.6/ssl.py", line 407, in wrap_socket
    _context=self, _session=session)
  File "/usr/lib/python3.6/ssl.py", line 817, in __init__
    self.do_handshake()
  File "/usr/lib/python3.6/ssl.py", line 1077, in do_handshake
    self._sslobj.do_handshake()
  File "/usr/lib/python3.6/ssl.py", line 689, in do_handshake
    self._sslobj.do_handshake()
ssl.SSLError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:852)
```

With verify=False.
```
>>> client = Client('https://127.0.0.1:8080', verify=False)
/home/vikas/.virtualenvs/qbittorrent/lib/python3.6/site-packages/urllib3/connectionpool.py:1004: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning,
>>> client.login('admin', 'password')
/home/vikas/.virtualenvs/qbittorrent/lib/python3.6/site-packages/urllib3/connectionpool.py:1004: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning,
>>> client.qbittorrent_version
/home/vikas/.virtualenvs/qbittorrent/lib/python3.6/site-packages/urllib3/connectionpool.py:1004: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning,
'v4.2.0RC'
>>> 

```