### PR TITLE
Added a timeout option to the Client

### DIFF
--- a/qbittorrent/client.py
+++ b/qbittorrent/client.py
@@ -9,22 +9,27 @@ class LoginRequired(Exception):
 
 class Client(object):
     """class to interact with qBittorrent WEB API"""
-    def __init__(self, url, verify=True):
+    def __init__(self, url, verify=True, timeout=None):
         """
         Initialize the client
 
         :param url: Base URL of the qBittorrent WEB API
         :param verify: Boolean to specify if SSL verification should be done.
-                       Defaults to True.
+                       Defaults to True. 
+        :param timeout: How many seconds to wait for the server to send data
+                        before giving up, as a float, or a
+                        `(connect timeout, read timeout)` tuple.
+                       Defaults to None.
         """
         if not url.endswith('/'):
             url += '/'
         self.url = url + 'api/v2/'
         self.verify = verify
+        self.timeout = timeout
 
         session = requests.Session()
         prefs_url = self.url + 'app/preferences'
-        check_prefs = session.get(prefs_url, verify=self.verify)
+        check_prefs = session.get(prefs_url, verify=self.verify, timeout=self.timeout)
         if check_prefs.status_code == 200:
             self._is_authenticated = True
             self.session = session
@@ -80,6 +85,7 @@ class Client(object):
             raise LoginRequired
 
         kwargs['verify'] = self.verify
+        kwargs['timeout'] = self.timeout
         if method == 'get':
             request = self.session.get(final_url, **kwargs)
         else:


### PR DESCRIPTION
Hi everyone!

I just decided to create my own remote client desktop for qBittorrent and found your awesome library. I think it's lacking an option to setup the timeout as by default [and according to requests library documentation](https://2.python-requests.org/en/master/user/advanced/#timeouts):

>Most requests to external servers should have a timeout attached, in case the server is not responding in a timely manner. By default, requests do not time out unless a timeout value is set explicitly. Without a timeout, your code may hang for minutes or more.

I'm interesting on a timeout to avoid my application to hang forever. I think it should be useful to define it in the `Client` constructor. Looking forward for your feedback