### PR TITLE
Fix set_torrent_location by sending a dummy file

### DIFF
--- a/qbittorrent/client.py
+++ b/qbittorrent/client.py
@@ -404,7 +404,10 @@ class Client(object):
         """
         data = self._process_infohash_list(infohash_list)
         data['location'] = location
-        return self._post('torrents/setLocation', data=data)
+        # workaround to send multipart/formdata request
+        # http://stackoverflow.com/a/23131823/4726598
+        dummy_file = {'_dummy': (None, '_dummy')}
+        return self._post('torrents/setLocation', data=data, files=dummy_file)
 
     def set_torrent_name(self, infohash, name):
         """


### PR DESCRIPTION
This is the same workaround as 4157765 to avoid spaces being converted to plus signs but for set_torrent_location()