### PR TITLE
Update README.md so sample code (i.e., "print") works in Python 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ qb.login('admin', 'your-secret-password')
 torrents = qb.torrents()
 
 for torrent in torrents:
-    print torrent['name']
+    print(torrent['name'])
 ```
 
 If you have enabled SSL and are using a self-signed certificate, you\'d


### PR DESCRIPTION
I tried copying the sample code, but I got an error since `print torrent['name']` is Python 2 style. This PR updates sample code so it uses Python 3 style. Anyone who needs Python 2 style can remove parentheses. Presumably by this time (year 2024) Python 3 is far more prevalent than Python 2.